### PR TITLE
Remove slash from host

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 FORMAT: 1A
-HOST: https://mainnet.blockchainos.org/
+HOST: https://mainnet.blockchainos.org
 
 # Sebak Client API
 SEBAK, the next BOScoin network with ISAAC consensus protocol. 


### PR DESCRIPTION
Previous Host name makes duplicated slash in api url like below
```https://mainnet.blockchainos.org//api/v1/accounts/GDEPYGGALPJ5HENXCNOQJPPDOQMA2YAXPERZ4XEAKVFFJJEVP4ZBK6QI```